### PR TITLE
Pass HFO detector object to callback

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,16 +2,17 @@
 
 import numpy as np
 from snn_hfo_ieeg.run import run_hfo_detection
-from snn_hfo_ieeg.entrypoint.hfo_detection import HfoDetectionRun
+from snn_hfo_ieeg.entrypoint.hfo_detection import HfoDetector, Metadata
 
 
-def _print_hfo(hfo_detection_run: HfoDetectionRun):
+def _print_hfo(metadata: Metadata, hfo_detector: HfoDetector):
     print(
-        f'Results for patient {hfo_detection_run.patient}, interval {hfo_detection_run.interval} and channel {hfo_detection_run.channel}')
-    print(f'SNN simulation ran for {hfo_detection_run.duration} seconds')
-    print('Number of HFO events: ', hfo_detection_run.hfo_detection.total_amount)
+        f'Patient {metadata.patient}, interval {metadata.interval}, channel {metadata.channel}')
+    print(f'SNN simulation will run for {metadata.duration} seconds')
+    hfo_detection = hfo_detector.run()
+    print('Number of HFO events: ', hfo_detection.total_amount)
     print('Rate of HFO (event/min)',
-          np.around(hfo_detection_run.hfo_detection.frequency * 60, decimals=2))
+          np.around(hfo_detection.frequency * 60, decimals=2))
     print('------')
 
 

--- a/snn_hfo_ieeg/functions/hfo_detection.py
+++ b/snn_hfo_ieeg/functions/hfo_detection.py
@@ -26,7 +26,7 @@ class Periods(NamedTuple):
     stop: np.array
 
 
-class PlottingData(NamedTuple):
+class Analytics(NamedTuple):
     '''
     Convenience data that can be used for plotting.
 
@@ -54,12 +54,24 @@ class HfoDetection(NamedTuple):
         The measured frequency of HFOs per second. This is the most important value.
     total_amount : int
         Total amount of detected HFOs over the entire dataset.
-    plotting_data : PlottingData
-        Convenience data that a user can use for their plotting.
     '''
     frequency: float
     total_amount: int
-    plotting_data: PlottingData
+
+
+class HfoDetectionWithAnalytics(NamedTuple):
+    '''
+    The result of the SNNs HFO detection
+
+    Parameters
+    -----
+    result : HfoDetection
+        The HFO detection result
+    analytics : Analytics
+        Convenience data that a user can use for their plotting.
+    '''
+    result: HfoDetection
+    analytics: Analytics
 
 
 def _did_snn_find_hfo(spike_times, window):
@@ -128,10 +140,12 @@ def detect_hfo(duration, spike_times, signal_times, step_size, window_size):
     periods = _find_periods(binary_hfo_signal, signal_times)
     flat_periods = _flatten_periods(periods)
 
-    return HfoDetection(
-        total_amount=len(periods),
-        frequency=len(periods)/duration,
-        plotting_data=PlottingData(
+    return HfoDetectionWithAnalytics(
+        result=HfoDetection(
+            total_amount=len(periods),
+            frequency=len(periods)/duration,
+        ),
+        analytics=Analytics(
             detections=binary_hfo_signal,
             analyzed_times=signal_times,
             periods=flat_periods

--- a/tests/functions/test_hfo_detection.py
+++ b/tests/functions/test_hfo_detection.py
@@ -1,14 +1,16 @@
 import pytest
-from snn_hfo_ieeg.functions.hfo_detection import Periods, detect_hfo, HfoDetection, PlottingData
+from snn_hfo_ieeg.functions.hfo_detection import Periods, detect_hfo, HfoDetectionWithAnalytics, HfoDetection, Analytics
 from tests.utility import *
 
 
 @pytest.mark.parametrize(
     'duration, spike_monitor, original_time_vector, step_size, window_size, expected_hfo_detection',
-    [(1, [0], np.array([0]), 0.1, 0.1, HfoDetection(
-        total_amount=1,
-        frequency=1,
-        plotting_data=PlottingData(
+    [(1, [0], np.array([0]), 0.1, 0.1, HfoDetectionWithAnalytics(
+        result=HfoDetection(
+            total_amount=1,
+            frequency=1,
+        ),
+        analytics=Analytics(
             detections=[1],
             analyzed_times=[0],
             periods=Periods(
@@ -16,10 +18,12 @@ from tests.utility import *
                 stop=[0]
             )
         ))),
-     (1, [0.5], np.array([0.5]), 0.1, 0.5, HfoDetection(
-         total_amount=1,
-         frequency=1,
-         plotting_data=PlottingData(
+     (1, [0.5], np.array([0.5]), 0.1, 0.5, HfoDetectionWithAnalytics(
+         result=HfoDetection(
+             total_amount=1,
+             frequency=1,
+         ),
+         analytics=Analytics(
              detections=[1],
              analyzed_times=[0.5],
              periods=Periods(
@@ -27,10 +31,12 @@ from tests.utility import *
                  stop=[0.5]
              )
          ))),
-     (2, [-0.5], np.array([-0.5]), -0.1, -0.05, HfoDetection(
-         total_amount=0,
-         frequency=0,
-         plotting_data=PlottingData(
+     (2, [-0.5], np.array([-0.5]), -0.1, -0.05, HfoDetectionWithAnalytics(
+         result=HfoDetection(
+             total_amount=0,
+             frequency=0,
+         ),
+         analytics=Analytics(
              detections=[0],
              analyzed_times=[-0.5],
              periods=Periods(
@@ -38,10 +44,12 @@ from tests.utility import *
                  stop=[]
              )
          ))),
-     (0.001, np.arange(0, 300, 5e-4), [0.2, 0.3], 0.01, 0.05, HfoDetection(
-         total_amount=0,
-         frequency=0,
-         plotting_data=PlottingData(
+     (0.001, np.arange(0, 300, 5e-4), [0.2, 0.3], 0.01, 0.05, HfoDetectionWithAnalytics(
+         result=HfoDetection(
+             total_amount=0,
+             frequency=0,
+         ),
+         analytics=Analytics(
              detections=[0, 0],
              analyzed_times=[0.2, 0.3],
              periods=Periods(

--- a/tests/utility.py
+++ b/tests/utility.py
@@ -11,12 +11,12 @@ def are_hfo_detections_equal(first_hfo, second_hfo):
     def are_values_same(property_cb):
         return are_lists_approximately_equal(
             property_cb(first_hfo), property_cb(second_hfo))
-    return first_hfo.total_amount == second_hfo.total_amount \
-        and first_hfo.frequency == second_hfo.frequency \
-        and are_values_same(lambda hfo: hfo.plotting_data.analyzed_times) \
-        and are_values_same(lambda hfo: hfo.plotting_data.detections) \
-        and are_values_same(lambda hfo: hfo.plotting_data.periods.start) \
-        and are_values_same(lambda hfo: hfo.plotting_data.periods.stop)
+    return first_hfo.result.total_amount == second_hfo.result.total_amount \
+        and first_hfo.result.frequency == pytest.approx(second_hfo.result.frequency) \
+        and are_values_same(lambda hfo: hfo.analytics.analyzed_times) \
+        and are_values_same(lambda hfo: hfo.analytics.detections) \
+        and are_values_same(lambda hfo: hfo.analytics.periods.start) \
+        and are_values_same(lambda hfo: hfo.analytics.periods.stop)
 
 
 def get_tests_path():


### PR DESCRIPTION
The user's callback now receives a [`Metadata`](https://github.com/kburel/snn-hfo-detection/pull/66/files#diff-9fd4a4406388f5390a5720ddb066e4c44816733dcca1d2c0c059aa2c356ab1a4R17) and an `HfoDetector` with can either `run()` or `run_with_analytics()`.