### PR TITLE
Cache brian2 network as much as possible

### DIFF
--- a/snn_hfo_ieeg/entrypoint/hfo_detection.py
+++ b/snn_hfo_ieeg/entrypoint/hfo_detection.py
@@ -6,8 +6,6 @@ from snn_hfo_ieeg.stages.all import run_all_hfo_detection_stages
 from snn_hfo_ieeg.stages.loading.patient_data import load_patient_data, extract_channel_data
 from snn_hfo_ieeg.stages.loading.folder_discovery import get_patient_interval_paths
 
-_SNN_CACHE = None
-
 
 class CustomOverrides(NamedTuple):
     duration: float
@@ -40,26 +38,30 @@ def _calculate_duration(signal_time):
     return np.max(signal_time) + extra_simulation_time
 
 
-def _generate_hfo_detection_cb(channel_data, duration, configuration):
+def _generate_hfo_detection_cb(channel_data, duration, configuration, snn_cache):
     inner_channel_data = deepcopy(channel_data)
     inner_configuration = deepcopy(configuration)
     return lambda: run_all_hfo_detection_stages(
         channel_data=inner_channel_data,
         duration=duration,
         configuration=inner_configuration,
-        snn_cache=_SNN_CACHE)
+        snn_cache=snn_cache)
 
 
-def _generate_hfo_detector(channel_data, duration, configuration):
+def _generate_hfo_detector(channel_data, duration, configuration, snn_cache):
     hfo_detection_cb = _generate_hfo_detection_cb(
-        channel_data, duration, configuration)
+        channel_data, duration, configuration, snn_cache)
     return HfoDetector(
         lambda: hfo_detection_cb().result, hfo_detection_cb)
 
 
 def run_hfo_detection_with_configuration(configuration, custom_overrides, hfo_cb):
+    # Cache needs this lifetime
+    snn_cache = None
+
     patient_intervals_paths = get_patient_interval_paths(
         configuration.data_path)
+
     for patient, intervals in patient_intervals_paths.items():
         if custom_overrides.patients is not None and patient not in custom_overrides.patients:
             continue
@@ -82,6 +84,6 @@ def run_hfo_detection_with_configuration(configuration, custom_overrides, hfo_cb
                     duration=duration
                 )
                 hfo_detector = _generate_hfo_detector(
-                    channel_data, duration, configuration)
+                    channel_data, duration, configuration, snn_cache)
 
                 hfo_cb(metadata, hfo_detector)

--- a/snn_hfo_ieeg/entrypoint/hfo_detection.py
+++ b/snn_hfo_ieeg/entrypoint/hfo_detection.py
@@ -6,6 +6,8 @@ from snn_hfo_ieeg.stages.all import run_all_hfo_detection_stages
 from snn_hfo_ieeg.stages.loading.patient_data import load_patient_data, extract_channel_data
 from snn_hfo_ieeg.stages.loading.folder_discovery import get_patient_interval_paths
 
+_SNN_CACHE = {}
+
 
 class CustomOverrides(NamedTuple):
     duration: float
@@ -44,7 +46,8 @@ def _generate_hfo_detection_cb(channel_data, duration, configuration):
     return lambda: run_all_hfo_detection_stages(
         channel_data=inner_channel_data,
         duration=duration,
-        configuration=inner_configuration)
+        configuration=inner_configuration,
+        snn_cache=_SNN_CACHE)
 
 
 def _generate_hfo_detector(channel_data, duration, configuration):

--- a/snn_hfo_ieeg/entrypoint/hfo_detection.py
+++ b/snn_hfo_ieeg/entrypoint/hfo_detection.py
@@ -6,7 +6,7 @@ from snn_hfo_ieeg.stages.all import run_all_hfo_detection_stages
 from snn_hfo_ieeg.stages.loading.patient_data import load_patient_data, extract_channel_data
 from snn_hfo_ieeg.stages.loading.folder_discovery import get_patient_interval_paths
 
-_SNN_CACHE = {}
+_SNN_CACHE = None
 
 
 class CustomOverrides(NamedTuple):

--- a/snn_hfo_ieeg/stages/all.py
+++ b/snn_hfo_ieeg/stages/all.py
@@ -7,12 +7,13 @@ HFO_DETECTION_STEP_SIZE = 0.01
 HFO_DETECTION_WINDOW_SIZE = 0.05
 
 
-def run_all_hfo_detection_stages(channel_data, duration, configuration):
+def run_all_hfo_detection_stages(channel_data, duration, configuration, snn_cache):
     filtered_spikes = filter_stage(channel_data, configuration)
     spike_monitor_hidden = snn_stage(
         filtered_spikes=filtered_spikes,
         duration=duration,
-        configuration=configuration)
+        configuration=configuration,
+        cache=snn_cache)
 
     return detect_hfo(duration=duration,
                       spike_times=(

--- a/snn_hfo_ieeg/stages/snn/stage.py
+++ b/snn_hfo_ieeg/stages/snn/stage.py
@@ -85,19 +85,20 @@ def snn_stage(filtered_spikes, duration, configuration, cache):
             cache['hidden_layer'], cache['spike_monitor_hidden'])
         cache['network'].store()
 
-    cache['network'].restore()
+    network = cache['network']
+    network.restore()
     input_layer = _create_input_layer(
         filtered_spikes, cache['neuron_counts'].input)
-    cache['network'].add(input_layer)
+    network.add(input_layer)
     synapses = _create_synapses(
         input_layer,
         cache['hidden_layer'],
         cache['model_paths'],
         cache['neuron_counts'])
 
-    cache['network'].add(synapses)
-    cache['network'].run(duration * second)
-    cache['network'].remove(input_layer)
-    cache['network'].remove(synapses)
+    network.add(synapses)
+    network.run(duration * second)
+    network.remove(input_layer)
+    network.remove(synapses)
 
     return cache['spike_monitor_hidden']

--- a/snn_hfo_ieeg/stages/snn/stage.py
+++ b/snn_hfo_ieeg/stages/snn/stage.py
@@ -90,15 +90,16 @@ def _create_cache(configuration):
     spike_monitor_hidden = SpikeMonitor(hidden_layer)
     network = Network(
         hidden_layer, spike_monitor_hidden)
-    cache = Cache(
+
+    network.store()
+
+    return Cache(
         model_paths=model_paths,
         neuron_counts=neuron_counts,
         hidden_layer=hidden_layer,
         spike_monitor_hidden=spike_monitor_hidden,
         network=network
     )
-    cache.network.store()
-    return cache
 
 
 def snn_stage(filtered_spikes, duration, configuration, cache: Cache):
@@ -110,15 +111,17 @@ def snn_stage(filtered_spikes, duration, configuration, cache: Cache):
 
     input_layer = _create_input_layer(
         filtered_spikes, cache.neuron_counts.input)
-    cache.network.add(input_layer)
     synapses = _create_synapses(
         input_layer,
         cache.hidden_layer,
         cache.model_paths,
         cache.neuron_counts)
 
+    cache.network.add(input_layer)
     cache.network.add(synapses)
+
     cache.network.run(duration * second)
+
     cache.network.remove(input_layer)
     cache.network.remove(synapses)
 


### PR DESCRIPTION
This caches everything but the inputs and synapses, which are re-created on every channel.
So, in essence, the hidden layer and spike monitor are cached.
Fixes #32 