### PR TITLE
Detect thresholds based on calibration time instead of all times

### DIFF
--- a/snn_hfo_ieeg/entrypoint/argument_parsing.py
+++ b/snn_hfo_ieeg/entrypoint/argument_parsing.py
@@ -16,7 +16,7 @@ def parse_arguments():
     parser.add_argument('--duration', type=float, default=None,
                         help='How many seconds of the dataset should be processed. By default, the entire dataset will be processed')
     parser.add_argument('--calibration', type=float, default=default_calibration,
-                        help=f'How many seconds of the dataset should be used for calibration of HFO thresholds. Default is {default_calibration} s. Calibration time is allowed to be bigger than duration.')
+                        help=f'How many seconds of the dataset should be used for calibration of HFO thresholds. Default is {default_calibration} s. If calibration is bigger than duration, the entire duration will be used for calibration.')
     parser.add_argument('--channels', type=int, default=None, nargs='+',
                         help='Which channels of the dataset should be processed, using 1 based indexing. By default, all channels will be processed')
     parser.add_argument('--patients', type=int, default=None, nargs='+',

--- a/snn_hfo_ieeg/entrypoint/argument_parsing.py
+++ b/snn_hfo_ieeg/entrypoint/argument_parsing.py
@@ -16,7 +16,7 @@ def parse_arguments():
     parser.add_argument('--duration', type=float, default=None,
                         help='How many seconds of the dataset should be processed. By default, the entire dataset will be processed')
     parser.add_argument('--calibration', type=float, default=default_calibration,
-                        help=f'How many seconds of the dataset should be used for calibration. Default is {default_calibration} s. Calibration time is allowed to be bigger than duration.')
+                        help=f'How many seconds of the dataset should be used for calibration of HFO thresholds. Default is {default_calibration} s. Calibration time is allowed to be bigger than duration.')
     parser.add_argument('--channels', type=int, default=None, nargs='+',
                         help='Which channels of the dataset should be processed, using 1 based indexing. By default, all channels will be processed')
     parser.add_argument('--patients', type=int, default=None, nargs='+',

--- a/snn_hfo_ieeg/entrypoint/argument_parsing.py
+++ b/snn_hfo_ieeg/entrypoint/argument_parsing.py
@@ -8,12 +8,15 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='Perform an hfo test run')
     default_data_path = 'data/'
     default_hidden_neurons = 86
+    default_calibration = 1
     parser.add_argument('--data-path', type=str, default=default_data_path,
                         help=f'Specifies the path to the directory containing the test data. Default is {default_data_path}')
     parser.add_argument('--hidden-neurons', type=int, default=default_hidden_neurons,
                         help=f'How many neurons should be in the hidden layer. Default is {default_hidden_neurons}')
     parser.add_argument('--duration', type=float, default=None,
                         help='How many seconds of the dataset should be processed. By default, the entire dataset will be processed')
+    parser.add_argument('--calibration', type=float, default=default_calibration,
+                        help=f'How many seconds of the dataset should be used for calibration. Default is {default_calibration} s. Calibration time is allowed to be bigger than duration.')
     parser.add_argument('--channels', type=int, default=None, nargs='+',
                         help='Which channels of the dataset should be processed, using 1 based indexing. By default, all channels will be processed')
     parser.add_argument('--patients', type=int, default=None, nargs='+',
@@ -30,7 +33,8 @@ def convert_arguments_to_config(arguments):
     return Configuration(
         data_path=arguments.data_path,
         measurement_mode=MeasurementMode[arguments.mode.upper()],
-        hidden_neuron_count=arguments.hidden_neurons
+        hidden_neuron_count=arguments.hidden_neurons,
+        calibration_time=arguments.calibration
     )
 
 

--- a/snn_hfo_ieeg/entrypoint/argument_parsing.py
+++ b/snn_hfo_ieeg/entrypoint/argument_parsing.py
@@ -8,7 +8,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='Perform an hfo test run')
     default_data_path = 'data/'
     default_hidden_neurons = 86
-    default_calibration = 1
+    default_calibration = 10
     parser.add_argument('--data-path', type=str, default=default_data_path,
                         help=f'Specifies the path to the directory containing the test data. Default is {default_data_path}')
     parser.add_argument('--hidden-neurons', type=int, default=default_hidden_neurons,

--- a/snn_hfo_ieeg/functions/signal_to_spike.py
+++ b/snn_hfo_ieeg/functions/signal_to_spike.py
@@ -80,7 +80,7 @@ def find_thresholds(signals, times, window_size, sample_ratio, scaling_factor):
 # ========================================================================================
 # Signal to spike conversion with refractory period
 # ========================================================================================
-def signal_to_spike_refractory(interpfact, times, amplitude, thr_up, thr_dn, refractory_period):
+def signal_to_spike_refractory(interpolation_factor, times, amplitude, thr_up, thr_dn, refractory_period):
     '''
     This functions retuns two spike trains, when the signal crosses the specified threshold in
     a rising direction (UP spikes) and when it crosses the specified threshold in a falling
@@ -88,7 +88,7 @@ def signal_to_spike_refractory(interpfact, times, amplitude, thr_up, thr_dn, ref
 
     :times (array): time vector
     :amplitude (array): amplitude of the signal
-    :interpfact (int): upsampling factor, new sampling frequency
+    :interpolation_factor (int): upsampling factor, new sampling frequency
     :thr_up (float): threshold crossing in a rising direction
     :thr_dn (float): threshold crossing in a falling direction
     :refractory_period (float): period in which no spike will be generated [same units as time vector]
@@ -98,7 +98,7 @@ def signal_to_spike_refractory(interpfact, times, amplitude, thr_up, thr_dn, ref
     spike_dn = []
 
     intepolated_time = sc.interpolate.interp1d(times, amplitude)
-    rangeint = np.round((np.max(times) - np.min(times))*interpfact)
+    rangeint = np.round((np.max(times) - np.min(times))*interpolation_factor)
     xnew = np.linspace(np.min(times), np.max(
         times), num=int(rangeint), endpoint=True)
     data = np.reshape([xnew, intepolated_time(xnew)], (2, len(xnew))).T
@@ -108,11 +108,11 @@ def signal_to_spike_refractory(interpfact, times, amplitude, thr_up, thr_dn, ref
         if((actual_dc + thr_up) < data[i, 1]):
             spike_up.append(data[i, 0])  # spike up
             actual_dc = data[i, 1]        # update current dc value
-            i += int(refractory_period * interpfact)
+            i += int(refractory_period * interpolation_factor)
         elif((actual_dc - thr_dn) > data[i, 1]):
             spike_dn.append(data[i, 0])  # spike dn
             actual_dc = data[i, 1]        # update curre
-            i += int(refractory_period * interpfact)
+            i += int(refractory_period * interpolation_factor)
         else:
             i += 1
 

--- a/snn_hfo_ieeg/functions/signal_to_spike.py
+++ b/snn_hfo_ieeg/functions/signal_to_spike.py
@@ -73,7 +73,7 @@ def find_thresholds(signals, times, window_size, step_size, sample_ratio, scalin
         max_min_amplitude[interval_nr, 0] = max_amplitude
         max_min_amplitude[interval_nr, 1] = min_amplitude
 
-    chosen_samples = int(np.round(num_timesteps * sample_ratio))
+    chosen_samples = max(int(np.round(num_timesteps * sample_ratio)), 1)
     threshold_up = np.mean(np.sort(max_min_amplitude[:, 0])[:chosen_samples])
     threshold_dn = np.mean(
         np.sort(max_min_amplitude[:, 1] * -1)[:chosen_samples])

--- a/snn_hfo_ieeg/functions/signal_to_spike.py
+++ b/snn_hfo_ieeg/functions/signal_to_spike.py
@@ -15,7 +15,7 @@ class SpikeTrains(NamedTuple):
     down: np.array
 
 
-def find_thresholds(signals, times, window_size, step_size, sample_ratio, scaling_factor):
+def find_thresholds(signals, times, window_size, sample_ratio, scaling_factor):
     '''
     This functions retuns the mean threshold for your signals, based on the calculated
     mean noise floor and a user-specified scaling facotr that depeneds on the type of signals,
@@ -36,9 +36,6 @@ def find_thresholds(signals, times, window_size, step_size, sample_ratio, scalin
      scaling_factor : float
         a percentage of the calculated threshold
     '''
-    if step_size > window_size:
-        raise ValueError(
-            f'step_size needs to be at most windows_size, but got: step_size={step_size}, window_size={step_size}')
     min_time = np.min(times)
     if np.min(times) < 0:
         raise ValueError(
@@ -63,9 +60,9 @@ def find_thresholds(signals, times, window_size, step_size, sample_ratio, scalin
             f'sample_ratio must be a value between 0 and 1, but was {sample_ratio}'
         )
 
-    num_timesteps = int(np.ceil(duration / step_size))
+    num_timesteps = int(np.ceil(duration / window_size))
     max_min_amplitude = np.zeros((num_timesteps, 2))
-    for interval_nr, interval_start in enumerate(np.arange(start=0, stop=duration, step=step_size)):
+    for interval_nr, interval_start in enumerate(np.arange(start=0, stop=duration, step=window_size)):
         interval_end = interval_start + window_size
         index = np.where((times >= interval_start) & (times <= interval_end))
         max_amplitude = np.max(signals[index])

--- a/snn_hfo_ieeg/stages/filter.py
+++ b/snn_hfo_ieeg/stages/filter.py
@@ -7,6 +7,7 @@ from snn_hfo_ieeg.stages.shared_config import MeasurementMode
 
 
 SAMPLING_FREQUENCY = 2000
+CALIBRATION_TIME = 1
 
 
 class FilteredSpikes(NamedTuple):
@@ -37,11 +38,14 @@ class _FilterParameters(NamedTuple):
         highcut frequency
     scaling_factor: float
         new scaling factor
+    calibration_time: float
+        time that should be used to find thresholds
     '''
     channel_data: ChannelData
     lowcut: int
     highcut: int
     scaling_factor: float
+    calibration_time: float
 
 
 def _filter_signal_to_spike(filter_parameters):

--- a/snn_hfo_ieeg/stages/filter.py
+++ b/snn_hfo_ieeg/stages/filter.py
@@ -7,7 +7,6 @@ from snn_hfo_ieeg.stages.shared_config import MeasurementMode
 
 
 SAMPLING_FREQUENCY = 2000
-CALIBRATION_TIME = 1
 
 
 class FilteredSpikes(NamedTuple):
@@ -96,13 +95,15 @@ def filter_stage(channel_data, configuration):
         channel_data=channel_data,
         lowcut=80,
         highcut=250,
-        scaling_factor=0.6
+        scaling_factor=0.6,
+        calibration_time=configuration.calibration_time
     ))
     fast_ripple = _filter_signal_to_spike(_FilterParameters(
         channel_data=channel_data,
         lowcut=250,
         highcut=500,
-        scaling_factor=0.3
+        scaling_factor=0.3,
+        calibration_time=configuration.calibration_time
     ))
 
     return _filter_spikes_according_to_measurement_mode(

--- a/snn_hfo_ieeg/stages/filter.py
+++ b/snn_hfo_ieeg/stages/filter.py
@@ -52,8 +52,8 @@ def _get_signal_times_in_calibration_time(signal, filter_parameters):
     signal_times_in_calibration = [(signal, time) for signal, time
                                    in signal_times
                                    if time <= filter_parameters.calibration_time]
-    signals = [signal for signal, _ in signal_times_in_calibration]
-    times = [time for _, time in signal_times_in_calibration]
+    signals = np.array([signal for signal, _ in signal_times_in_calibration])
+    times = np.array([time for _, time in signal_times_in_calibration])
     return signals, times
 
 

--- a/snn_hfo_ieeg/stages/filter.py
+++ b/snn_hfo_ieeg/stages/filter.py
@@ -69,7 +69,6 @@ def _filter_signal_to_spike(filter_parameters):
     thresholds = np.ceil(find_thresholds(signals=calibration_signals,
                                          times=calibration_times,
                                          window_size=1,
-                                         step_size=1,
                                          sample_ratio=1/6,
                                          scaling_factor=filter_parameters.scaling_factor))
     return signal_to_spike_refractory(interpfact=35000,

--- a/snn_hfo_ieeg/stages/filter.py
+++ b/snn_hfo_ieeg/stages/filter.py
@@ -71,7 +71,7 @@ def _filter_signal_to_spike(filter_parameters):
                                          window_size=1,
                                          sample_ratio=1/6,
                                          scaling_factor=filter_parameters.scaling_factor))
-    return signal_to_spike_refractory(interpfact=35000,
+    return signal_to_spike_refractory(interpolation_factor=35000,
                                       times=filter_parameters.channel_data.signal_time,
                                       amplitude=signal,
                                       thr_up=thresholds, thr_dn=thresholds,

--- a/snn_hfo_ieeg/stages/filter.py
+++ b/snn_hfo_ieeg/stages/filter.py
@@ -68,7 +68,7 @@ def _filter_signal_to_spike(filter_parameters):
         signal, filter_parameters)
     thresholds = np.ceil(find_thresholds(signals=calibration_signals,
                                          times=calibration_times,
-                                         window_size=1,
+                                         window_size=0.5,
                                          sample_ratio=1/6,
                                          scaling_factor=filter_parameters.scaling_factor))
     return signal_to_spike_refractory(interpolation_factor=35000,

--- a/snn_hfo_ieeg/stages/shared_config.py
+++ b/snn_hfo_ieeg/stages/shared_config.py
@@ -12,3 +12,4 @@ class Configuration(NamedTuple):
     data_path: str
     measurement_mode: MeasurementMode
     hidden_neuron_count: int
+    calibration_time: float

--- a/tests/functions/test_signal_to_spike.py
+++ b/tests/functions/test_signal_to_spike.py
@@ -33,7 +33,7 @@ def test_find_thresholds_does_not_accept_invalid_percentages(sample_ratio):
 
 
 @pytest.mark.parametrize(
-    'interpfact, time, amplitude, thr_up, thr_dn, refractory_period, expected_spike_trains',
+    'interpolation_factor, time, amplitude, thr_up, thr_dn, refractory_period, expected_spike_trains',
     [(1, [0, 1], [1, 0], 3, 0.5, 0.01, SpikeTrains(up=[], down=[])),
      (10, [0, 1, 2], [0, 10, -20], 3, 0.5, 0.01, SpikeTrains(up=[0.3157894736842105, 0.631578947368421, 0.9473684210526315],
                                                              down=[1.0526315789473684, 1.1578947368421053,
@@ -45,9 +45,9 @@ def test_find_thresholds_does_not_accept_invalid_percentages(sample_ratio):
                                                                                        3.007537688442211, 3.6090452261306534],
                                                                                    down=[0.0]))]
 )
-def test_signal_to_spike_refractory(interpfact, time, amplitude, thr_up, thr_dn, refractory_period, expected_spike_trains):
+def test_signal_to_spike_refractory(interpolation_factor, time, amplitude, thr_up, thr_dn, refractory_period, expected_spike_trains):
     spike_trains = signal_to_spike_refractory(
-        interpfact, time, amplitude, thr_up, thr_dn, refractory_period)
+        interpolation_factor, time, amplitude, thr_up, thr_dn, refractory_period)
     assert are_lists_approximately_equal(
         spike_trains.up, expected_spike_trains.up)
     assert are_lists_approximately_equal(

--- a/tests/functions/test_signal_to_spike.py
+++ b/tests/functions/test_signal_to_spike.py
@@ -4,17 +4,17 @@ from tests.utility import *
 
 
 @pytest.mark.parametrize(
-    'signals, time, window, step_size, sample_ratio, scaling_factor, expected_mean_threshold',
+    'signals, time, window, sample_ratio, scaling_factor, expected_mean_threshold',
     [(np.array([0, 1]),
-      np.array([0, 1]), 1, 1, 0.9, 0.1, 0.1),
+      np.array([0, 1]), 1, 0.9, 0.1, 0.1),
      (np.array([-0.6, -2, -5, 10, 20, 0.2, -3, 0.4]),
-      np.arange(0, 0.8, 0.1), 1, 1, 0.9, 0.6, 15.0),
+      np.arange(0, 0.8, 0.1), 1, 0.9, 0.6, 15.0),
      (np.arange(-20, 20, 0.1),
-      np.arange(0, 4, 0.01), 1, 1, 0.4, 0.6, -6)]
+      np.arange(0, 4, 0.01), 1, 0.4, 0.6, -6)]
 )
-def test_find_thresholds(signals, time, window, step_size, sample_ratio, scaling_factor, expected_mean_threshold):
+def test_find_thresholds(signals, time, window, sample_ratio, scaling_factor, expected_mean_threshold):
     mean_threshold = find_thresholds(
-        signals, time, window, step_size, sample_ratio, scaling_factor)
+        signals, time, window, sample_ratio, scaling_factor)
     assert expected_mean_threshold == pytest.approx(mean_threshold)
 
 
@@ -28,7 +28,6 @@ def test_find_thresholds_does_not_accept_invalid_percentages(sample_ratio):
             signals=np.array([0, 1]),
             times=np.array([0, 1]),
             window_size=1,
-            step_size=1,
             sample_ratio=sample_ratio,
             scaling_factor=0.1)
 

--- a/tests/integration/test_hfo_detection_from_dataset.py
+++ b/tests/integration/test_hfo_detection_from_dataset.py
@@ -26,7 +26,7 @@ def _generate_test_configuration(dataset_name, measurement_mode=MeasurementMode.
         data_path=_get_hfo_directory(dataset_name),
         measurement_mode=measurement_mode,
         hidden_neuron_count=86,
-        calibration_time=1
+        calibration_time=10
     )
 
 

--- a/tests/integration/test_hfo_detection_from_dataset.py
+++ b/tests/integration/test_hfo_detection_from_dataset.py
@@ -82,7 +82,7 @@ def test_ieeg_hfo_detection():
         hfo_cb=_generate_add_detected_hfo_to_list_cb(detected_hfos))
     assert len(detected_hfos) == 1
     hfo = detected_hfos[0]
-    assert hfo.result.frequency == pytest.approx(0.08, abs=FREQUENCY_ACCURACY)
+    assert hfo.result.frequency == pytest.approx(0.14, abs=FREQUENCY_ACCURACY)
 
     _assert_contains_at_least([0.0, 3.5, 6.43, 10.59, 14.29, 17.42, 24.2],
                               hfo.analytics.periods.start, accuracy=PERIOD_ACCURACY)

--- a/tests/integration/test_hfo_detection_from_dataset.py
+++ b/tests/integration/test_hfo_detection_from_dataset.py
@@ -26,6 +26,7 @@ def _generate_test_configuration(dataset_name, measurement_mode=MeasurementMode.
         data_path=_get_hfo_directory(dataset_name),
         measurement_mode=measurement_mode,
         hidden_neuron_count=86,
+        calibration_time=1
     )
 
 

--- a/tests/integration/test_hfo_detection_from_dataset.py
+++ b/tests/integration/test_hfo_detection_from_dataset.py
@@ -82,7 +82,7 @@ def test_ieeg_hfo_detection():
         hfo_cb=_generate_add_detected_hfo_to_list_cb(detected_hfos))
     assert len(detected_hfos) == 1
     hfo = detected_hfos[0]
-    assert hfo.result.frequency == pytest.approx(0.12, abs=FREQUENCY_ACCURACY)
+    assert hfo.result.frequency == pytest.approx(0.08, abs=FREQUENCY_ACCURACY)
 
     _assert_contains_at_least([0.0, 3.5, 6.43, 10.59, 14.29, 17.42, 24.2],
                               hfo.analytics.periods.start, accuracy=PERIOD_ACCURACY)

--- a/tests/integration/test_plotting.py
+++ b/tests/integration/test_plotting.py
@@ -21,7 +21,8 @@ def _run_hfo_detection_with_plot_and_cb(plot_name, hfo_cb):
             data_path=get_hfo_directory('dummy'),
             measurement_mode=MeasurementMode.IEEG,
             hidden_neuron_count=86,
-            plots=find_plotting_functions([plot_name])
+            plots=find_plotting_functions([plot_name]),
+            calibration_time=10
         ),
         custom_overrides=EMPTY_CUSTOM_OVERRIDES,
         hfo_cb=hfo_cb)


### PR DESCRIPTION
Fixes #38 
Default calibration time is 10 s
## Without calibration
![image](https://user-images.githubusercontent.com/9047632/127865758-fe95eb3e-6a7f-4f73-9b40-2bdf6957eada.png)

## Different calibration values
![image](https://user-images.githubusercontent.com/9047632/127865808-5cef3a40-d2a0-4cec-915a-3d59ce3304d0.png)
![image](https://user-images.githubusercontent.com/9047632/127865834-3b493f25-b367-4600-9d0e-cc1b3341a64e.png)
![image](https://user-images.githubusercontent.com/9047632/127865857-79cbb969-2e4f-4cf2-b7a4-deee852c56dc.png)
![image](https://user-images.githubusercontent.com/9047632/127865876-6187f81a-5f1d-4f25-9ce6-8f1ca0a92021.png)
Last one uses `window_size = 0.1` and `step_size = 0.01`. `window_size = 0.1`  and `step_size = 0.1 `changes next to nothing.

