### PR TITLE
Disable annoying brian error message

### DIFF
--- a/brian_preferences
+++ b/brian_preferences
@@ -1,0 +1,1 @@
+logging.display_brian_error_message = False


### PR DESCRIPTION
Disables the following message appearing on _any_ error

> ERROR      Brian 2 encountered an unexpected error. If you think this is a bug in Brian 2, please report this issue either to 
the discourse forum at <http://brian.discourse.group/>, or to the issue tracker at <https://github.com/brian-team/brian2/issues>. Please include this file with debug information in your report: /var/folders/ct/56ng5mfn2838m8d5d2bcd9ph0000gn/T/brian_debug_q9foa48d.log  Additionally, you can also include a copy of the script that was run, available at: /var/folders/ct/56ng5mfn2838m8d5d2bcd9ph0000gn/T/brian_script_fyfzsy1b.py Thanks! [brian2]
