### PR TITLE
Implement mean HFO diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ or after the entire patient. Note that multiple plots can be speficied.
 - **raster**: Classic neuron ID to spike time raster plot. On gets drawn when an HFO was detected.
 
 ### Per patient plots
+- **mean_hfo_rate**: Plots the mean HFO rates of the channels along with their standard deviation
 
 ## This code has been written originally by:
 * Karla Burelo

--- a/snn_hfo_ieeg/entrypoint/hfo_detection.py
+++ b/snn_hfo_ieeg/entrypoint/hfo_detection.py
@@ -2,24 +2,18 @@ from copy import deepcopy
 from typing import List, NamedTuple, Optional
 import numpy as np
 from snn_hfo_ieeg.stages.all import run_all_hfo_detection_stages
-from snn_hfo_ieeg.user_facing_data import HfoDetection, HfoDetectionWithAnalytics
+from snn_hfo_ieeg.user_facing_data import HfoDetection, HfoDetectionWithAnalytics, Metadata
 from snn_hfo_ieeg.stages.loading.patient_data import load_patient_data, extract_channel_data
 from snn_hfo_ieeg.stages.loading.folder_discovery import get_interval_paths
 from snn_hfo_ieeg.stages.persistence.loading import load_hfo_detection
 from snn_hfo_ieeg.plotting.persistence import persist_patient_plot, persist_channel_plot
+from snn_hfo_ieeg.plotting.plot_patient import ChannelData, Intervals
 
 
 class CustomOverrides(NamedTuple):
     duration: Optional[float]
     channels: Optional[List[int]]
     intervals: Optional[List[int]]
-
-
-class Metadata(NamedTuple):
-    interval: int
-    channel: int
-    channel_label: str
-    duration: float
 
 
 class HfoDetector():
@@ -70,7 +64,7 @@ def run_hfo_detection_with_configuration(configuration, custom_overrides, hfo_cb
 
     intervals = get_interval_paths(configuration.data_path)
     should_collect_patient_data = len(configuration.plots.patient) != 0
-    patient_hfos = []
+    patient_hfos: Intervals = {}
     for interval, interval_path in intervals.items():
         if custom_overrides.intervals is not None and interval not in custom_overrides.intervals:
             continue
@@ -78,6 +72,7 @@ def run_hfo_detection_with_configuration(configuration, custom_overrides, hfo_cb
         duration = custom_overrides.duration if custom_overrides.duration is not None else _calculate_duration(
             patient_data.signal_time)
 
+        channel_hfos = []
         for channel in range(len(patient_data.wideband_signals)):
             if custom_overrides.channels is not None and channel + 1 not in custom_overrides.channels:
                 continue
@@ -100,9 +95,11 @@ def run_hfo_detection_with_configuration(configuration, custom_overrides, hfo_cb
                     persist_channel_plot(
                         plotting_fn.name, metadata, configuration)
                 if should_collect_patient_data:
-                    patient_hfos.append(
-                        hfo_detector.last_run)
-
-        for plotting_fn in configuration.plots.patient:
-            plotting_fn.function(patient_hfos)
-            persist_patient_plot(plotting_fn.name, configuration)
+                    channel_hfos.append(
+                        ChannelData(
+                            metadata=metadata,
+                            hfo_detection=hfo_detector.last_run))
+        patient_hfos[interval] = channel_hfos
+    for plotting_fn in configuration.plots.patient:
+        plotting_fn.function(patient_hfos)
+        persist_patient_plot(plotting_fn.name, configuration)

--- a/snn_hfo_ieeg/plotting/plot_channel.py
+++ b/snn_hfo_ieeg/plotting/plot_channel.py
@@ -1,23 +1,24 @@
 import matplotlib.pyplot as plt
 from brian2.units import second, ms
+from snn_hfo_ieeg.user_facing_data import HfoDetectionWithAnalytics
 
 
 class ChannelDebugError(Exception):
-    def __init__(self, message, hfo_detection):
+    def __init__(self, message, hfo_detection: HfoDetectionWithAnalytics):
         super().__init__(message)
         self.hfo_detection = hfo_detection
 
 
-def plot_internal_channel_debug(hfo_detection):
+def plot_internal_channel_debug(hfo_detection: HfoDetectionWithAnalytics):
     raise ChannelDebugError(
         "plot_internal_channel_debug is just here for debugging purposes and should not be called",
         hfo_detection)
 
 
-def plot_raster(hfo_detection):
+def plot_raster(hfo_detection: HfoDetectionWithAnalytics):
     if hfo_detection.result.total_amount == 0:
         return
     plt.plot(hfo_detection.analytics.spike_times*second/ms,
-           hfo_detection.analytics.neuron_ids, '.k')
+             hfo_detection.analytics.neuron_ids, '.k')
     plt.xlabel('Time (ms)')
     plt.ylabel('Neuron index')

--- a/snn_hfo_ieeg/plotting/plot_mean_hfo_rate.py
+++ b/snn_hfo_ieeg/plotting/plot_mean_hfo_rate.py
@@ -1,0 +1,83 @@
+from statistics import mean
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def _append_or_create(dict, key, value):
+    if key not in dict:
+        dict[key] = [value]
+    else:
+        dict[key].append(value)
+
+
+def _convert_to_labels_to_hfo_rate_dict(intervals):
+    label_to_hfo_rates = {}
+    for channels in intervals.values():
+        for channel in channels:
+            _append_or_create(
+                dict=label_to_hfo_rates,
+                key=channel.metadata.channel_label,
+                value=channel.hfo_detection.result.frequency * 60)
+
+    return label_to_hfo_rates
+
+
+def _plot_bar(axes, intervals):
+    label_to_hfo_rates = _convert_to_labels_to_hfo_rate_dict(intervals)
+
+    labels = list(label_to_hfo_rates.keys())
+    hfo_rates = label_to_hfo_rates.values()
+
+    mean_hfo_rates = [mean(_) for _ in hfo_rates]
+    standard_deviations = [np.std(_) for _ in hfo_rates] \
+        if len(intervals) > 1 else None
+    axes.bar(
+        x=labels,
+        height=mean_hfo_rates,
+        width=0.3,
+        edgecolor='k',
+        ecolor='#0218f5',
+        alpha=0.9, color='#2f70b6',
+        yerr=standard_deviations,
+        capsize=2)
+
+
+def _rotate_labels(axes):
+    labels = axes.get_xticklabels()
+    for label in labels:
+        label.set_rotation(45)
+        label.set_horizontalalignment('right')
+        label.set_size = 16
+
+
+def _set_layout(fig):
+    plt.rc('font', family='sans-serif')
+    plt.tight_layout()
+    fig.subplots_adjust(bottom=0.25, left=0.1, wspace=0.2, hspace=0.2)
+
+
+def _style_ticks(axes):
+    axes.set_ylim(bottom=0)
+    axes.set_xlabel('Electrode label', fontsize=18)
+    axes.set_ylabel('HFO rate (event/min)', fontsize=18)
+
+    axes.tick_params(axis='y', labelsize=16, length=8)
+    axes.tick_params(axis='x', labelsize=16, length=8)
+
+
+def _hide_spines(axes):
+    axes.spines['top'].set_visible(False)
+    axes.spines['right'].set_visible(False)
+
+
+def plot_mean_hfo_rate(intervals):
+    if len(intervals) == 0:
+        return
+
+    fig, axes = plt.subplots(figsize=(15, 5))
+
+    _set_layout(fig)
+    _plot_bar(axes, intervals)
+    _rotate_labels(axes)
+    _style_ticks(axes)
+    _hide_spines(axes)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -66,6 +66,14 @@ def _plot_bar(axes, intervals):
         capsize=2)
 
 
+def _rotate_labels(axes):
+    labels = axes.get_xticklabels()
+    for label in labels:
+        label.set_rotation(45)
+        label.set_horizontalalignment('right')
+        label.set_size = 16
+
+
 def plot_mean_hfo_rate(intervals: Intervals):
     if len(intervals) == 0:
         return
@@ -73,15 +81,10 @@ def plot_mean_hfo_rate(intervals: Intervals):
     fig, axes = plt.subplots(figsize=(15, 5))
     plt.rc('font', family='sans-serif')
     plt.tight_layout()
-    fig.subplots_adjust(bottom=0.15, wspace=0.2, hspace=0.2)
+    fig.subplots_adjust(bottom=0.25, left=0.1, wspace=0.2, hspace=0.2)
 
     _plot_bar(axes, intervals)
-
-    labels = axes.get_xticklabels()
-    for label in labels:
-        label.set_rotation(45)
-        label.set_horizontalalignment('right')
-        label.set_size = 16
+    _rotate_labels(axes)
 
     axes.set_xlabel('Electrode label', fontsize=18)
     axes.set_ylabel('HFO rate (event/min)', fontsize=18)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -81,6 +81,7 @@ def _set_layout(fig):
 
 
 def _style_ticks(axes):
+    axes.set_ylim(bottom=0)
     axes.set_xlabel('Electrode label', fontsize=18)
     axes.set_ylabel('HFO rate (event/min)', fontsize=18)
 
@@ -98,7 +99,7 @@ def plot_mean_hfo_rate(intervals: Intervals):
         return
 
     fig, axes = plt.subplots(figsize=(15, 5))
-    
+
     _set_layout(fig)
     _plot_bar(axes, intervals)
     _rotate_labels(axes)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -56,11 +56,12 @@ def plot_mean_hfo_rate(intervals: Intervals):
     fig, axes = plt.subplots(figsize=figure_size)
     plt.rc('font', family='sans-serif')
     plt.tight_layout()
-    fig.subplots_adjust(wspace=0.2, hspace=0.2)
+    fig.subplots_adjust(bottom=0.15, wspace=0.2, hspace=0.2)
 
     axes.bar(
         x=labels,
         height=mean_hfo_rates,
+        width=0.3,
         edgecolor='k',
         ecolor='#0218f5',
         alpha=0.9, color='#2f70b6',

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -74,23 +74,33 @@ def _rotate_labels(axes):
         label.set_size = 16
 
 
-def plot_mean_hfo_rate(intervals: Intervals):
-    if len(intervals) == 0:
-        return
-
-    fig, axes = plt.subplots(figsize=(15, 5))
+def _set_layout(fig):
     plt.rc('font', family='sans-serif')
     plt.tight_layout()
     fig.subplots_adjust(bottom=0.25, left=0.1, wspace=0.2, hspace=0.2)
 
-    _plot_bar(axes, intervals)
-    _rotate_labels(axes)
 
+def _style_ticks(axes):
     axes.set_xlabel('Electrode label', fontsize=18)
     axes.set_ylabel('HFO rate (event/min)', fontsize=18)
 
     axes.tick_params(axis='y', labelsize=16, length=8)
     axes.tick_params(axis='x', labelsize=16, length=8)
 
+
+def _hide_spines(axes):
     axes.spines['top'].set_visible(False)
     axes.spines['right'].set_visible(False)
+
+
+def plot_mean_hfo_rate(intervals: Intervals):
+    if len(intervals) == 0:
+        return
+
+    fig, axes = plt.subplots(figsize=(15, 5))
+    
+    _set_layout(fig)
+    _plot_bar(axes, intervals)
+    _rotate_labels(axes)
+    _style_ticks(axes)
+    _hide_spines(axes)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -3,7 +3,6 @@ from statistics import mean
 import numpy as np
 import matplotlib.pyplot as plt
 from snn_hfo_ieeg.user_facing_data import HfoDetectionWithAnalytics, Metadata
-color_bars = ['#2f70b6', '#c85a2d', '#6f63b6', '#e26a84']
 
 
 class ChannelData(NamedTuple):
@@ -36,22 +35,46 @@ def _append_or_create(dict, key, value):
 
 
 def plot_mean_hfo_rate(intervals: Intervals):
+    if len(intervals) == 0:
+        return
+
     label_to_hfo_rates = {}
-    print(intervals)
     for channels in intervals.values():
         for channel in channels:
             _append_or_create(
                 dict=label_to_hfo_rates,
                 key=channel.metadata.channel_label,
                 value=channel.hfo_detection.result.frequency * 60)
-    labels = label_to_hfo_rates.keys()
+
+    labels = list(label_to_hfo_rates.keys())
     hfo_rates = label_to_hfo_rates.values()
     mean_hfo_rates = [mean(_) for _ in hfo_rates]
-    standard_deviations = [np.std(_) for _ in hfo_rates]
-    plt.ylabel('Average HFO rate per minute')
-    plt.xlabel('Channel')
-    plt.bar(
+    standard_deviations = [np.std(_) for _ in hfo_rates] \
+        if len(intervals) > 1 else None
+
+    figure_size = (15, 5)
+    fig, axes = plt.subplots(figsize=figure_size)
+    plt.rc('font', family='sans-serif')
+    plt.tight_layout()
+    fig.subplots_adjust(wspace=0.2, hspace=0.2)
+
+    axes.bar(
         x=labels,
         height=mean_hfo_rates,
+        edgecolor='k',
+        ecolor='#0218f5',
+        alpha=0.9, color='#2f70b6',
         yerr=standard_deviations,
         capsize=2)
+
+    axes.set_xticklabels(labels, rotation=45,
+                         fontsize=16, horizontalalignment='right')
+
+    axes.set_xlabel('Electrode label', fontsize=18)
+    axes.set_ylabel('HFO rate (event/min)', fontsize=18)
+
+    axes.tick_params(axis='y', labelsize=16, length=8)
+    axes.tick_params(axis='x', labelsize=16, length=8)
+
+    axes.spines['top'].set_visible(False)
+    axes.spines['right'].set_visible(False)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -1,10 +1,25 @@
+from typing import TypedDict, NamedTuple
+import matplotlib.pyplot as plt
+from snn_hfo_ieeg.user_facing_data import HfoDetectionWithAnalytics, Metadata
+
+
+class ChannelData(NamedTuple):
+    metadata: Metadata
+    hfo_detection: HfoDetectionWithAnalytics
+
+
+class Intervals(TypedDict):
+    index: int
+    channel_data: ChannelData
+
+
 class PatientDebugError(Exception):
-    def __init__(self, message, hfo_detections):
+    def __init__(self, message, intervals: Intervals):
         super().__init__(message)
-        self.hfo_detections = hfo_detections
+        self.intervals = intervals
 
 
-def plot_internal_patient_debug(hfo_detections):
+def plot_internal_patient_debug(intervals: Intervals):
     raise PatientDebugError(
         "plot_internal_patient_debug is just here for debugging purposes and should not be called",
-        hfo_detections)
+        intervals)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -67,6 +67,7 @@ def plot_mean_hfo_rate(intervals: Intervals):
         yerr=standard_deviations,
         capsize=2)
 
+    axes.set_xticks(labels)
     axes.set_xticklabels(labels, rotation=45,
                          fontsize=16, horizontalalignment='right')
 

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -1,8 +1,6 @@
 from typing import List, TypedDict, NamedTuple
-from statistics import mean
-import numpy as np
-import matplotlib.pyplot as plt
 from snn_hfo_ieeg.user_facing_data import HfoDetectionWithAnalytics, Metadata
+from snn_hfo_ieeg.plotting.plot_mean_hfo_rate import plot_mean_hfo_rate as inner_plot_mean_hfo_rate
 
 
 class ChannelData(NamedTuple):
@@ -27,81 +25,5 @@ def plot_internal_patient_debug(intervals: Intervals):
         intervals)
 
 
-def _append_or_create(dict, key, value):
-    if key not in dict:
-        dict[key] = [value]
-    else:
-        dict[key].append(value)
-
-
-def _convert_to_labels_to_hfo_rate_dict(intervals):
-    label_to_hfo_rates = {}
-    for channels in intervals.values():
-        for channel in channels:
-            _append_or_create(
-                dict=label_to_hfo_rates,
-                key=channel.metadata.channel_label,
-                value=channel.hfo_detection.result.frequency * 60)
-
-    return label_to_hfo_rates
-
-
-def _plot_bar(axes, intervals):
-    label_to_hfo_rates = _convert_to_labels_to_hfo_rate_dict(intervals)
-
-    labels = list(label_to_hfo_rates.keys())
-    hfo_rates = label_to_hfo_rates.values()
-
-    mean_hfo_rates = [mean(_) for _ in hfo_rates]
-    standard_deviations = [np.std(_) for _ in hfo_rates] \
-        if len(intervals) > 1 else None
-    axes.bar(
-        x=labels,
-        height=mean_hfo_rates,
-        width=0.3,
-        edgecolor='k',
-        ecolor='#0218f5',
-        alpha=0.9, color='#2f70b6',
-        yerr=standard_deviations,
-        capsize=2)
-
-
-def _rotate_labels(axes):
-    labels = axes.get_xticklabels()
-    for label in labels:
-        label.set_rotation(45)
-        label.set_horizontalalignment('right')
-        label.set_size = 16
-
-
-def _set_layout(fig):
-    plt.rc('font', family='sans-serif')
-    plt.tight_layout()
-    fig.subplots_adjust(bottom=0.25, left=0.1, wspace=0.2, hspace=0.2)
-
-
-def _style_ticks(axes):
-    axes.set_ylim(bottom=0)
-    axes.set_xlabel('Electrode label', fontsize=18)
-    axes.set_ylabel('HFO rate (event/min)', fontsize=18)
-
-    axes.tick_params(axis='y', labelsize=16, length=8)
-    axes.tick_params(axis='x', labelsize=16, length=8)
-
-
-def _hide_spines(axes):
-    axes.spines['top'].set_visible(False)
-    axes.spines['right'].set_visible(False)
-
-
 def plot_mean_hfo_rate(intervals: Intervals):
-    if len(intervals) == 0:
-        return
-
-    fig, axes = plt.subplots(figsize=(15, 5))
-
-    _set_layout(fig)
-    _plot_bar(axes, intervals)
-    _rotate_labels(axes)
-    _style_ticks(axes)
-    _hide_spines(axes)
+    inner_plot_mean_hfo_rate(intervals)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -34,10 +34,7 @@ def _append_or_create(dict, key, value):
         dict[key].append(value)
 
 
-def plot_mean_hfo_rate(intervals: Intervals):
-    if len(intervals) == 0:
-        return
-
+def _convert_to_labels_to_hfo_rate_dict(intervals):
     label_to_hfo_rates = {}
     for channels in intervals.values():
         for channel in channels:
@@ -46,18 +43,18 @@ def plot_mean_hfo_rate(intervals: Intervals):
                 key=channel.metadata.channel_label,
                 value=channel.hfo_detection.result.frequency * 60)
 
+    return label_to_hfo_rates
+
+
+def _plot_bar(axes, intervals):
+    label_to_hfo_rates = _convert_to_labels_to_hfo_rate_dict(intervals)
+
     labels = list(label_to_hfo_rates.keys())
     hfo_rates = label_to_hfo_rates.values()
+
     mean_hfo_rates = [mean(_) for _ in hfo_rates]
     standard_deviations = [np.std(_) for _ in hfo_rates] \
         if len(intervals) > 1 else None
-
-    figure_size = (15, 5)
-    fig, axes = plt.subplots(figsize=figure_size)
-    plt.rc('font', family='sans-serif')
-    plt.tight_layout()
-    fig.subplots_adjust(bottom=0.15, wspace=0.2, hspace=0.2)
-
     axes.bar(
         x=labels,
         height=mean_hfo_rates,
@@ -68,9 +65,23 @@ def plot_mean_hfo_rate(intervals: Intervals):
         yerr=standard_deviations,
         capsize=2)
 
-    axes.set_xticks(labels)
-    axes.set_xticklabels(labels, rotation=45,
-                         fontsize=16, horizontalalignment='right')
+
+def plot_mean_hfo_rate(intervals: Intervals):
+    if len(intervals) == 0:
+        return
+
+    fig, axes = plt.subplots(figsize=(15, 5))
+    plt.rc('font', family='sans-serif')
+    plt.tight_layout()
+    fig.subplots_adjust(bottom=0.15, wspace=0.2, hspace=0.2)
+
+    _plot_bar(axes, intervals)
+
+    labels = axes.get_xticklabels()
+    for label in labels:
+        label.set_rotation(45)
+        label.set_horizontalalignment('right')
+        label.set_size = 16
 
     axes.set_xlabel('Electrode label', fontsize=18)
     axes.set_ylabel('HFO rate (event/min)', fontsize=18)

--- a/snn_hfo_ieeg/plotting/plot_patient.py
+++ b/snn_hfo_ieeg/plotting/plot_patient.py
@@ -3,6 +3,7 @@ from statistics import mean
 import numpy as np
 import matplotlib.pyplot as plt
 from snn_hfo_ieeg.user_facing_data import HfoDetectionWithAnalytics, Metadata
+color_bars = ['#2f70b6', '#c85a2d', '#6f63b6', '#e26a84']
 
 
 class ChannelData(NamedTuple):
@@ -47,6 +48,8 @@ def plot_mean_hfo_rate(intervals: Intervals):
     hfo_rates = label_to_hfo_rates.values()
     mean_hfo_rates = [mean(_) for _ in hfo_rates]
     standard_deviations = [np.std(_) for _ in hfo_rates]
+    plt.ylabel('Average HFO rate per minute')
+    plt.xlabel('Channel')
     plt.bar(
         x=labels,
         height=mean_hfo_rates,

--- a/snn_hfo_ieeg/stages/persistence/loading.py
+++ b/snn_hfo_ieeg/stages/persistence/loading.py
@@ -53,7 +53,7 @@ def load_hfo_detection(loading_path, metadata) -> HfoDetectionWithAnalytics:
     filepath = get_persistence_path(loading_path, metadata)
     if not path.isfile(filepath):
         raise ValueError(
-            f'No HFO detection data was saved for patient {metadata.patient}, interval {metadata.interval}, channel {metadata.channel}')
+            f'No HFO detection data was saved for interval {metadata.interval}, channel {metadata.channel}')
     dictionary = sio.loadmat(filepath)
     _remove_matlab_keys(dictionary)
     return _deserialize_matlab(dictionary, HfoDetectionWithAnalytics)

--- a/snn_hfo_ieeg/stages/persistence/loading.py
+++ b/snn_hfo_ieeg/stages/persistence/loading.py
@@ -24,7 +24,9 @@ def _deserialize_inner_matlab(item, type: NamedTuple):
         value = params[property_name]
         property_type = outer_property_type.__args__[0] if _is_optional(
             outer_property_type) else outer_property_type
-        if str(value[0]) == 'None':
+        if len(value) == 0:
+            params[property_name] = []
+        elif str(value[0]) == 'None':
             params[property_name] = None
         elif _has_annotations(property_type):
             params[property_name] = _deserialize_inner_matlab(

--- a/snn_hfo_ieeg/user_facing_data.py
+++ b/snn_hfo_ieeg/user_facing_data.py
@@ -98,3 +98,10 @@ class HfoDetectionWithAnalytics(NamedTuple):
     '''
     result: HfoDetection
     analytics: Analytics
+
+
+class Metadata(NamedTuple):
+    interval: int
+    channel: int
+    channel_label: str
+    duration: float

--- a/tests/integration/test_hfo_detection_from_dataset.py
+++ b/tests/integration/test_hfo_detection_from_dataset.py
@@ -87,10 +87,10 @@ def test_ieeg_hfo_detection():
     hfo = detected_hfos[0]
     assert hfo.result.frequency == pytest.approx(0.14, abs=FREQUENCY_ACCURACY)
 
-    _assert_contains_at_least([0.0, 3.5, 6.43, 10.59, 14.29, 17.42, 24.2],
+    _assert_contains_at_least([0.0, 3.5, 6.43, 10.59, 14.29, 17.42],
                               hfo.analytics.periods.start, accuracy=PERIOD_ACCURACY)
 
-    _assert_contains_at_least([0.06, 3.59, 6.54, 10.72, 14.39, 17.53, 24.29],
+    _assert_contains_at_least([0.06, 3.59, 6.54, 10.72, 14.39, 17.53],
                               hfo.analytics.periods.stop, accuracy=PERIOD_ACCURACY)
 
 

--- a/tests/integration/test_hfo_detection_from_dataset.py
+++ b/tests/integration/test_hfo_detection_from_dataset.py
@@ -70,7 +70,7 @@ def _generate_add_detected_hfo_to_list_cb(detected_hfos):
     return add_detected_hfo_to_list
 
 
-def _assert_contains_at_least(actual, expected, accuracy):
+def _assert_contains_at_least(expected, actual, accuracy):
     approx_actual = [pytest.approx(element, abs=accuracy)
                      for element in actual]
     for element in expected:


### PR DESCRIPTION
Fixes #85 
Running `poetry run ./run.py ieeg --duration 1 --plot mean_hfo_rate` yields the following plot
![mean_hfo_rate](https://user-images.githubusercontent.com/9047632/128318867-69ac2efe-0467-48a3-9297-27d5fec47278.png)
It looks a bit boring since the HFO rates are rather homogeneous at duration = 1 s
The standard deviation whiskers only get shown if more than one interval was analyzed.
Edit: Plot of full duration:
![mean_hfo_rate](https://user-images.githubusercontent.com/9047632/128356897-6e03a1a3-cb03-4ad9-8fc7-914f908dbe96.png)
